### PR TITLE
Build export tagged docker image

### DIFF
--- a/cf/cmd/exporter/main.go
+++ b/cf/cmd/exporter/main.go
@@ -82,7 +82,7 @@ func export() error {
 			return packs.FailErr(err, "transform", dropletPath, "into layer")
 		}
 		defer os.Remove(layer)
-		repoImage, err = img.Append(stackImage, layer)
+		repoImage, _, err = img.Append(stackImage, layer)
 		if err != nil {
 			return packs.FailErr(err, "append droplet to", stackName)
 		}

--- a/cf/metadata.go
+++ b/cf/metadata.go
@@ -13,7 +13,11 @@ type DropletMetadata struct {
 func (d *DropletMetadata) Buildpacks() []packs.BuildpackMetadata {
 	var out []packs.BuildpackMetadata
 	for _, bp := range d.LifecycleMetadata.Buildpacks {
-		out = append(out, packs.BuildpackMetadata(bp))
+		out = append(out, packs.BuildpackMetadata{
+			Key:     bp.Key,
+			Name:    bp.Name,
+			Version: bp.Version,
+		})
 	}
 	return out
 }

--- a/img/actions.go
+++ b/img/actions.go
@@ -12,16 +12,16 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
-func Append(base v1.Image, tar string) (v1.Image, error) {
+func Append(base v1.Image, tar string) (v1.Image, v1.Layer, error) {
 	layer, err := tarball.LayerFromFile(tar)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	image, err := mutate.AppendLayers(base, layer)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return image, nil
+	return image, layer, nil
 }
 
 type ImageFinder func(labels map[string]string) (v1.Image, error)

--- a/img/store.go
+++ b/img/store.go
@@ -62,7 +62,7 @@ func (d *daemonStore) Ref() name.Reference {
 }
 
 func (d *daemonStore) Image() (v1.Image, error) {
-	return daemon.Image(d.tag, nil)
+	return daemon.Image(d.tag, &daemon.ReadOptions{})
 }
 
 func (d *daemonStore) Write(image v1.Image) error {

--- a/metadata.go
+++ b/metadata.go
@@ -12,9 +12,10 @@ type BuildMetadata struct {
 }
 
 type BuildpackMetadata struct {
-	Key     string `json:"key"`
-	Name    string `json:"name"`
-	Version string `json:"version,omitempty"`
+	Key     string                   `json:"key"`
+	Name    string                   `json:"name"`
+	Version string                   `json:"version,omitempty"`
+	Layers  map[string]LayerMetadata `json:"layers,omitempty"`
 }
 
 type AppMetadata struct {
@@ -25,4 +26,9 @@ type AppMetadata struct {
 type StackMetadata struct {
 	Name string `json:"name"`
 	SHA  string `json:"sha"`
+}
+
+type LayerMetadata struct {
+	SHA  string      `json:"sha"`
+	Data interface{} `json:"data"`
 }

--- a/v3/bin/build
+++ b/v3/bin/build
@@ -5,6 +5,7 @@ set -eo pipefail
 cd $(dirname "${BASH_SOURCE[0]}")/..
 
 stack=$1
+lifecycle_ref=$2
 samples_tgz=https://api.github.com/repos/buildpack/samples/tarball/master
 buildpack_dir=$(pwd)/images/detect/buildpacks
 nodejs_dir=$buildpack_dir/sh.packs.samples.buildpack.nodejs/latest
@@ -17,7 +18,7 @@ fi
 rm -rf "$buildpack_dir"
 mkdir -p "$nodejs_dir"
 
-if [[ "$(uname)" -eq "Linux" ]]; then
+if [[ $(uname) = Linux ]]; then
   curl -sSL "$samples_tgz" | tar -xzf - -C "$nodejs_dir" --strip-components=2 --wildcards 'buildpack-samples-*/nodejs-buildpack'
 else
   curl -sSL "$samples_tgz" | tar -xzf - -C "$nodejs_dir" --strip-components=2 'buildpack-samples-*/nodejs-buildpack'
@@ -31,8 +32,14 @@ echo 'groups = [{ repository = "packs/v3", buildpacks = ["sh.packs.samples.build
 
 docker pull "${stack}"
 
-docker build --build-arg "stack=${stack}" -t packs/v3:latest -f images/Dockerfile.base .
+if [[ -n $lifecycle_ref ]]; then
+  docker build --build-arg "stack=${stack}" --build-arg "lifecycle_ref=${lifecycle_ref}" -t packs/v3:latest -f images/Dockerfile.base .
+else
+  docker build --build-arg "stack=${stack}" -t packs/v3:latest -f images/Dockerfile.base .
+fi
 docker build -t packs/v3:detect images/detect
+docker build -t packs/v3:analyze images/analyze
 docker build -t packs/v3:build images/build
+docker build -t packs/v3:export images/export
 docker build -t packs/v3:run images/run
 

--- a/v3/bin/publish
+++ b/v3/bin/publish
@@ -6,5 +6,7 @@ cd $(dirname "${BASH_SOURCE[0]}")/..
 
 docker push packs/v3:latest
 docker push packs/v3:detect
+docker push packs/v3:analyze
 docker push packs/v3:build
+docker push packs/v3:export
 docker push packs/v3:run

--- a/v3/images/Dockerfile.base
+++ b/v3/images/Dockerfile.base
@@ -6,7 +6,7 @@ ARG lifecycle_ref=51e61d6
 ARG lifecycle_repo=github.com/buildpack/lifecycle
 
 WORKDIR /go/src/${lifecycle_repo}
-RUN git clone --single-branch "https://${lifecycle_repo}" . && \
+RUN git clone "https://${lifecycle_repo}" . && \
   git checkout "${lifecycle_ref}"
 RUN CGO_ENABLED=0 go install -a -installsuffix static "${lifecycle_repo}/cmd/..."
 
@@ -16,3 +16,4 @@ RUN useradd -u 1000 -mU -s /bin/bash packs
 COPY --from=lifecycle /go/bin /packs
 
 WORKDIR /workspace
+RUN chown -R packs /workspace

--- a/v3/images/analyze/Dockerfile
+++ b/v3/images/analyze/Dockerfile
@@ -1,0 +1,7 @@
+FROM packs/v3
+
+USER packs
+
+ENV PACK_BP_GROUP_PATH ./group.toml
+
+ENTRYPOINT ["/packs/analyzer"]

--- a/v3/images/export/Dockerfile
+++ b/v3/images/export/Dockerfile
@@ -1,0 +1,12 @@
+FROM packs/v3
+
+RUN apt-get update && \
+  apt-get install -y ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
+USER packs
+
+ENV PACK_BP_GROUP_PATH ./group.toml
+ENV PACK_METADATA_PATH ./metadata.toml
+
+ENTRYPOINT ["/packs/exporter"]


### PR DESCRIPTION
- add ca-certificates to export image
- allow lifecycle refs from any branch to be used during build
  (previously only refs on the master branch worked)

Signed-off-by: Emily Casey <ecasey@pivotal.io>
Signed-off-by: Dave Goddard <dave@goddard.id.au>
Signed-off-by: Steve Hiehn <shiehn@pivotal.io>