### PR TITLE
Add PACK_RUN_IMAGE to input

### DIFF
--- a/cf/images/export/Dockerfile
+++ b/cf/images/export/Dockerfile
@@ -12,7 +12,7 @@ ARG stack
 
 COPY --from=helpers /go/bin /usr/local/bin
 
-ENV PACK_STACK_NAME packs/${stack}:run
+ENV PACK_RUN_IMAGE packs/${stack}:run
 ENV PACK_USE_HELPERS true
 
 # TODO: remove

--- a/input.go
+++ b/input.go
@@ -25,6 +25,7 @@ const (
 	EnvDetectInfoPath = "PACK_DETECT_INFO_PATH"
 
 	EnvStackName  = "PACK_STACK_NAME"
+	EnvStackTag   = "PACK_STACK_TAG"
 	EnvUseDaemon  = "PACK_USE_DAEMON"
 	EnvUseHelpers = "PACK_USE_HELPERS"
 )
@@ -59,6 +60,10 @@ func InputDetectInfoPath(path *string) {
 
 func InputStackName(name *string) {
 	flag.StringVar(name, "stack", os.Getenv(EnvStackName), "image repository containing stack")
+}
+
+func InputStackTag(name *string) {
+	flag.StringVar(name, "stack", os.Getenv(EnvStackTag), "tag name of the stack")
 }
 
 func InputUseDaemon(use *bool) {

--- a/input.go
+++ b/input.go
@@ -24,8 +24,7 @@ const (
 	EnvBPGroupPath    = "PACK_BP_GROUP_PATH"
 	EnvDetectInfoPath = "PACK_DETECT_INFO_PATH"
 
-	EnvStackName  = "PACK_STACK_NAME"
-	EnvStackTag   = "PACK_STACK_TAG"
+	EnvRunImage   = "PACK_RUN_IMAGE"
 	EnvUseDaemon  = "PACK_USE_DAEMON"
 	EnvUseHelpers = "PACK_USE_HELPERS"
 )
@@ -58,12 +57,8 @@ func InputDetectInfoPath(path *string) {
 	flag.StringVar(path, "info", os.Getenv(EnvDetectInfoPath), "file containing detection info")
 }
 
-func InputStackName(name *string) {
-	flag.StringVar(name, "stack", os.Getenv(EnvStackName), "image repository containing stack")
-}
-
-func InputStackTag(name *string) {
-	flag.StringVar(name, "stack", os.Getenv(EnvStackTag), "tag name of the stack")
+func InputRunImage(name *string) {
+	flag.StringVar(name, "runImage", os.Getenv(EnvRunImage), "image repository containing stack")
 }
 
 func InputUseDaemon(use *bool) {

--- a/metadata.go
+++ b/metadata.go
@@ -9,7 +9,7 @@ type BuildMetadata struct {
 	App        AppMetadata         `json:"app"`
 	Config     ConfigMetadata      `json:"config"`
 	Buildpacks []BuildpackMetadata `json:"buildpacks"`
-	Stack      StackMetadata       `json:"stack"`
+	RunImage   RunImageMetadata    `json:"runimage"`
 }
 
 type BuildpackMetadata struct {
@@ -24,7 +24,7 @@ type AppMetadata struct {
 	SHA  string `json:"sha"`
 }
 
-type StackMetadata struct {
+type RunImageMetadata struct {
 	Name string `json:"name"`
 	SHA  string `json:"sha"`
 }


### PR DESCRIPTION
This allows the client to provide a custom tag for the stack image. This is necessary for Heroku's images (i.e. `heroku/heroku:18`), but it also facilitates testing of non-default images (i.e. `mystack/image:run-beta` or something)