### PR TITLE
Set build-image and run-image

### DIFF
--- a/v3/bin/build
+++ b/v3/bin/build
@@ -25,7 +25,7 @@ version_dir=$(dirname "$nodejs_dir")/$(cat "$nodejs_dir/buildpack.toml" | yj -t 
 mv "$nodejs_dir" "$version_dir"
 ln -s "$(basename "$version_dir")" "$nodejs_dir"
 
-echo 'groups = [{ repository = "packs/v3", buildpacks = [{ id = "sh.packs.samples.buildpack.nodejs", version = "latest" }] }]' > "$buildpack_dir/order.toml"
+echo 'groups = [{ repository = "packs/v3", build-image = "packs/v3:build", run-image = "packs/v3:run", buildpacks = [{ id = "sh.packs.samples.buildpack.nodejs", version = "latest" }] }]' > "$buildpack_dir/order.toml"
 
 docker pull "${stack}"
 


### PR DESCRIPTION
Leave deprecated "repository" field for old versions of pack

See: https://github.com/buildpack/pack/issues/17